### PR TITLE
Changing ZopeTransactionExtension to ZopeTransactionEvents

### DIFF
--- a/titledb/models.py
+++ b/titledb/models.py
@@ -27,12 +27,12 @@ from sqlalchemy.orm import (
 
 from sqlalchemy.sql import ( select, func, cast )
 
-from zope.sqlalchemy import ZopeTransactionExtension
+from zope.sqlalchemy import ZopeTransactionEvents
 
 from .jsonhelper import RenderSchema
 
 DBSession = scoped_session(
-    sessionmaker(extension=ZopeTransactionExtension()))
+    sessionmaker(extension=ZopeTransactionEvents()))
 Base = declarative_base()
 
 class GenericBase(AbstractConcreteBase, Base):


### PR DESCRIPTION
Changing ZopeTransactionExtension to ZopeTransactionEvents because ZopeTransactionExtension was renamed to ZopeTransactionEvents